### PR TITLE
migrate apps/v1beta1 to apps/v1

### DIFF
--- a/manifests/pgadmin-deployment.yaml
+++ b/manifests/pgadmin-deployment.yaml
@@ -18,7 +18,7 @@
 # scripts. There is no Service because we are using a very simple port-forward
 # to access the pod.
 
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pgadmin4-deployment


### PR DESCRIPTION
The current YAML is failed to create the deployment because the GKE's Kubernetes latest version is 1.16. In 1.16 `apps/v1beta1` API is removed [1]

[1] https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/